### PR TITLE
ci: run checkstyle

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,18 @@
 on:
-  push:
+  pull_request:
     branches:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Run Checkstyle
+        run: mvn checkstyle:check -Dcheckstyle.config.location=config/checkstyle.xml -DconsoleOutput=True -DfailOnViolation=True
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Issue
Para checar a estilização do código sem depender do desenvolvedor ter habilitado o hook de pré-commit, após um PR, é necessário rodar um status check que verifica o linting usando o CheckStyle.

## Proposta deste PR
* Rodar CheckStyle após PR
* Rodar testes após PR

## Impactos deste PR
* Roda ação `pr-checks` após qualquer PR para a branch `main`

## Evidências de teste
![Screenshot 2024-02-22 at 20 45 03](https://github.com/izaiasmachado/mandacarubroker/assets/47287096/93af19d2-d08b-4cec-9cd4-3f05574001e5)

![Screenshot 2024-02-22 at 20 45 29](https://github.com/izaiasmachado/mandacarubroker/assets/47287096/95a4d829-504d-4c12-890e-53fdd881216b)
