### PR TITLE
Fixing/git hook pre commit

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,17 +1,12 @@
 #!/bin/bash
+# Get a list of staged Java files
+staged_files=$(git diff --staged --name-only -- '*.java')
 
-# Get a list of staged files
-staged_files=$(git diff --staged --name-only)
-
-# Run Checkstyle only on staged files
+# Run Checkstyle only on staged Java files
 for file in $staged_files; do
-    if [[ $file != *.java ]]; then
-        continue
-    fi
-
     echo "Running Checkstyle on $file"
 
-    # Run Checkstyle on the staged file
+    # Run Checkstyle on the staged Java file
     mvn checkstyle:check -Dcheckstyle.config.location=config/checkstyle.xml -DconsoleOutput=True -DfailOnViolation=True -Dincludes=$file
     status=$?
 
@@ -21,13 +16,3 @@ for file in $staged_files; do
         exit 1
     fi
 done
-
-# Run unit tests
-mvn test
-
-# Check if the tests passed
-status=$?
-if [ $status -ne 0 ]; then
-    echo "Unit tests failed. Please fix them before committing."
-    exit 1
-fi

--- a/src/test/java/com/mandacarubroker/controller/StockControllerIT.java
+++ b/src/test/java/com/mandacarubroker/controller/StockControllerIT.java
@@ -61,7 +61,7 @@ class StockControllerIT {
     void tearDown() {
     }
 
-    void assertRequestDTOEqualsStock(final RequestStockDTO stockDTO, final Stock receivedStock) {
+    void assertRequestDTOEqualsStock(RequestStockDTO stockDTO, final Stock receivedStock) {
         assertEquals(stockDTO.symbol(), receivedStock.getSymbol());
         assertEquals(stockDTO.companyName(), receivedStock.getCompanyName());
         assertEquals(stockDTO.price(), receivedStock.getPrice());

--- a/src/test/java/com/mandacarubroker/controller/StockControllerIT.java
+++ b/src/test/java/com/mandacarubroker/controller/StockControllerIT.java
@@ -61,7 +61,7 @@ class StockControllerIT {
     void tearDown() {
     }
 
-    void assertRequestDTOEqualsStock(RequestStockDTO stockDTO, final Stock receivedStock) {
+    void assertRequestDTOEqualsStock(final RequestStockDTO stockDTO, final Stock receivedStock) {
         assertEquals(stockDTO.symbol(), receivedStock.getSymbol());
         assertEquals(stockDTO.companyName(), receivedStock.getCompanyName());
         assertEquals(stockDTO.price(), receivedStock.getPrice());


### PR DESCRIPTION
## Sobre este PR

Este PR possui o objetivo de ajustar o hook de pre-commit do git para observar e validar apenas códigos com extensões ```.java``` usando modelo de check style

## Impactos deste PR

Remoção de validações indevidas do check style em arquivos que não são JAVA

Todos deverão executar este comando na raiz do projeto:
```./setup_hooks.sh```
## Evidências de teste

![image](https://github.com/izaiasmachado/mandacarubroker/assets/70725719/1ed397e4-c7ef-4613-a15f-e343f192c2d2)
