### PR TITLE
feat: jwt after login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ MANDACARU_POSTGRES_PASSWORD=mandacaru
 # Change value to "never" for production environment
 MANDACARU_SQL_INIT_MODE=always
 MANDACARU_API_PORT=8080
+MANDACARU_JWT_SECRET=mandacaru-jwt-secret
 
 # Integration test environment
 MANDACARU_TEST_POSTGRES_HOST=127.0.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       MANDACARU_POSTGRES_USER: "time_dez"
       MANDACARU_POSTGRES_PASSWORD: "mandacaru"
       MANDACARU_POSTGRES_PORT: 5432
+      MANDACARU_JWT_SECRET: mandacaru-jwt-secret
       MANDACARU_TEST_POSTGRES_DB: "mandacaru_broker_test"
       MANDACARU_TEST_POSTGRES_USER: "time_dez_test"
       MANDACARU_TEST_POSTGRES_PASSWORD: "mandacaru"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
       MANDACARU_POSTGRES_USER: "time_dez"
       MANDACARU_POSTGRES_PASSWORD: "mandacaru"
       MANDACARU_POSTGRES_PORT: 5432
+      MANDACARU_JWT_SECRET: mandacaru-jwt-secret
       MANDACARU_TEST_POSTGRES_DB: "mandacaru_broker_test"
       MANDACARU_TEST_POSTGRES_USER: "time_dez_test"
       MANDACARU_TEST_POSTGRES_PASSWORD: "mandacaru"

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<java.version>17</java.version>
 		<sonar.organization>mandacaru-broker</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+		<powermock.version>2.0.2</powermock.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -71,6 +72,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.4.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
 			<version>5.0.7.RELEASE</version>
@@ -88,7 +94,6 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>com.puppycrawl.tools</groupId>
 			<artifactId>checkstyle</artifactId>

--- a/src/main/java/com/mandacarubroker/controller/AuthController.java
+++ b/src/main/java/com/mandacarubroker/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.mandacarubroker.controller;
 
 import com.mandacarubroker.domain.auth.RequestAuthUserDTO;
-import com.mandacarubroker.domain.user.User;
+import com.mandacarubroker.domain.auth.ResponseAuthUserDTO;
 import com.mandacarubroker.service.AuthService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -23,13 +23,13 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<String> login(@Valid @RequestBody final RequestAuthUserDTO requestAuthUserDTO) {
-        Optional<User> user = authService.login(requestAuthUserDTO);
+    public ResponseEntity<ResponseAuthUserDTO> login(@Valid @RequestBody final RequestAuthUserDTO requestAuthUserDTO) {
+        Optional<ResponseAuthUserDTO> responseAuthUserDTO = authService.login(requestAuthUserDTO);
 
-        if (user.isEmpty()) {
+        if (responseAuthUserDTO.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        return ResponseEntity.ok("User logged in successfully");
+        return ResponseEntity.ok(responseAuthUserDTO.orElseThrow());
     }
 }

--- a/src/main/java/com/mandacarubroker/domain/auth/ResponseAuthUserDTO.java
+++ b/src/main/java/com/mandacarubroker/domain/auth/ResponseAuthUserDTO.java
@@ -1,0 +1,8 @@
+package com.mandacarubroker.domain.auth;
+
+public record ResponseAuthUserDTO(
+        String token,
+        int expiresIn,
+        String tokenType
+) {
+}

--- a/src/main/java/com/mandacarubroker/security/MissingSecuritySecretException.java
+++ b/src/main/java/com/mandacarubroker/security/MissingSecuritySecretException.java
@@ -1,0 +1,7 @@
+package com.mandacarubroker.security;
+
+public class MissingSecuritySecretException extends RuntimeException {
+    public MissingSecuritySecretException(final String message) {
+        super("Missing security secret: " + message);
+    }
+}

--- a/src/main/java/com/mandacarubroker/security/SecuritySecrets.java
+++ b/src/main/java/com/mandacarubroker/security/SecuritySecrets.java
@@ -1,0 +1,16 @@
+package com.mandacarubroker.security;
+
+public final class SecuritySecrets {
+    private SecuritySecrets() {
+    }
+
+    public static String getJWTSecret() {
+        final String secret = System.getenv("MANDACARU_JWT_SECRET");
+
+        if (secret == null) {
+            throw new MissingSecuritySecretException("JWT secret not found");
+        }
+
+        return secret;
+    }
+}

--- a/src/main/java/com/mandacarubroker/service/AuthService.java
+++ b/src/main/java/com/mandacarubroker/service/AuthService.java
@@ -13,13 +13,14 @@ import static com.mandacarubroker.validation.RecordValidation.validateRequestDTO
 @Service
 public class AuthService {
     private final UserRepository userRepository;
+
     private final PasswordHashingService passwordHashingService;
     private final TokenService tokenService;
 
-    public AuthService(final UserRepository receivedUserRepository) {
-        this.userRepository = receivedUserRepository;
-        this.passwordHashingService = new PasswordHashingService();
-        this.tokenService = new TokenService();
+    public AuthService(final UserRepository receivedUserRepostory, final PasswordHashingService receivedPasswordHashingService, final TokenService receivedTokenService) {
+        this.userRepository = receivedUserRepostory;
+        this.passwordHashingService = receivedPasswordHashingService;
+        this.tokenService = receivedTokenService;
     }
 
     public Optional<ResponseAuthUserDTO> login(final RequestAuthUserDTO requestAuthUserDTO) {

--- a/src/main/java/com/mandacarubroker/service/PasswordHashingService.java
+++ b/src/main/java/com/mandacarubroker/service/PasswordHashingService.java
@@ -1,7 +1,9 @@
 package com.mandacarubroker.service;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
 
+@Service
 public class PasswordHashingService {
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 

--- a/src/main/java/com/mandacarubroker/service/PasswordHashingService.java
+++ b/src/main/java/com/mandacarubroker/service/PasswordHashingService.java
@@ -1,9 +1,7 @@
 package com.mandacarubroker.service;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
 
-@Service
 public class PasswordHashingService {
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 

--- a/src/main/java/com/mandacarubroker/service/TokenService.java
+++ b/src/main/java/com/mandacarubroker/service/TokenService.java
@@ -1,0 +1,63 @@
+package com.mandacarubroker.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.mandacarubroker.domain.auth.ResponseAuthUserDTO;
+import com.mandacarubroker.security.SecuritySecrets;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class TokenService {
+    private static final String TOKEN_ISSUER = "mandacaru-broker";
+    private static final int EXPIRATION_TIME = 864 * 1000 * 1000;
+    private static final int EXPIRATION_TIME_IN_SECONDS = EXPIRATION_TIME / 1000;
+    private static final String TOKEN_TYPE = "Bearer";
+    private final Algorithm algorithm;
+
+    public TokenService() {
+        String secret = SecuritySecrets.getJWTSecret();
+        algorithm = Algorithm.HMAC512(secret.getBytes());
+    }
+
+    public ResponseAuthUserDTO encodeToken(final String subject) {
+        try {
+            return tryToEncodeToken(subject);
+        } catch (JWTCreationException exception) {
+            return null;
+        }
+    }
+
+    private ResponseAuthUserDTO tryToEncodeToken(final String subject) {
+        Date expirationDate = new Date(System.currentTimeMillis() + EXPIRATION_TIME);
+
+        String generatedToken = JWT.create()
+                .withSubject(subject)
+                .withIssuer(TOKEN_ISSUER)
+                .withExpiresAt(expirationDate)
+                .sign(algorithm);
+
+        String tokenWithPrefix = TOKEN_TYPE + " " + generatedToken;
+        return new ResponseAuthUserDTO(tokenWithPrefix, EXPIRATION_TIME_IN_SECONDS, TOKEN_TYPE);
+    }
+
+    public String getTokenSubject(final String token) {
+        DecodedJWT decodedToken = decodeUserToken(token);
+        return decodedToken.getSubject();
+    }
+
+    public DecodedJWT decodeUserToken(final String token) {
+        try {
+            return tryToDecodeUserToken(token);
+        } catch (Exception exception) {
+            return null;
+        }
+    }
+
+    private DecodedJWT tryToDecodeUserToken(final String token) {
+        return JWT.require(algorithm).build().verify(token);
+    }
+}

--- a/src/test/java/com/mandacarubroker/security/SecuritySecretsMock.java
+++ b/src/test/java/com/mandacarubroker/security/SecuritySecretsMock.java
@@ -1,0 +1,20 @@
+package com.mandacarubroker.security;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public final class SecuritySecretsMock {
+    private static MockedStatic<SecuritySecrets> securitySecretsMockedStatic = null;
+
+    private SecuritySecretsMock() {
+    }
+
+    public static void mockStatic() {
+        if (securitySecretsMockedStatic != null) {
+            return;
+        }
+
+        securitySecretsMockedStatic = Mockito.mockStatic(SecuritySecrets.class);
+        securitySecretsMockedStatic.when(SecuritySecrets::getJWTSecret).thenReturn("secret");
+    }
+}

--- a/src/test/java/com/mandacarubroker/service/AuthServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.mandacarubroker.service;
 
 import com.mandacarubroker.domain.auth.RequestAuthUserDTO;
+import com.mandacarubroker.domain.auth.ResponseAuthUserDTO;
 import com.mandacarubroker.domain.user.RequestUserDTO;
 import com.mandacarubroker.domain.user.User;
 import com.mandacarubroker.domain.user.UserRepository;
@@ -19,13 +20,15 @@ class AuthServiceTest {
     @MockBean
     private UserRepository userRepository;
     private AuthService authService;
-    private final PasswordHashingService passwordHashingService = new PasswordHashingService();
+    private PasswordHashingService passwordHashingService;
+    private TokenService tokenService;
 
     private final String validEmail = "lara.souza@gmail.com";
     private final String validUsername = "username";
     private final String invalidUsername = "invalidUsername";
     private final String validPassword = "password";
-    private final String validHashedPassword = passwordHashingService.hashPassword(validPassword);
+    private final String invalidPassword = "invalidPassword";
+    private final String validHashedPassword = "hashedPassword";
     private final String validFirstName = "Lara";
     private final String validLastName = "Souza";
     private final LocalDate validBirthDate = LocalDate.of(1997,4,5);
@@ -41,6 +44,16 @@ class AuthServiceTest {
             validBalance
     );
 
+    private final RequestAuthUserDTO validRequestAuthUserDTO = new RequestAuthUserDTO(
+            validUsername,
+            validPassword
+    );
+
+    private final String validToken = "Bearer token";
+    private final int expiresIn = 86400;
+    private final String tokenType = "Bearer";
+
+
     private User validUser;
 
     @BeforeEach
@@ -52,7 +65,14 @@ class AuthServiceTest {
         Mockito.when(userRepository.findByUsername(validUsername)).thenReturn(validUser);
         Mockito.when(userRepository.findByUsername(invalidUsername)).thenReturn(null);
 
-        authService = new AuthService(userRepository);
+        passwordHashingService = Mockito.mock(PasswordHashingService.class);
+        Mockito.when(passwordHashingService.matches(validPassword, validHashedPassword)).thenReturn(true);
+        Mockito.when(passwordHashingService.matches(invalidPassword, validHashedPassword)).thenReturn(false);
+
+        tokenService = Mockito.mock(TokenService.class);
+        Mockito.when(tokenService.encodeToken(validUser.getId())).thenReturn(new ResponseAuthUserDTO(validToken, expiresIn, tokenType));
+
+        authService = new AuthService(userRepository, passwordHashingService, tokenService);
     }
 
     private void assertUsersAreEqual(final User expected, final User actual) {
@@ -66,34 +86,58 @@ class AuthServiceTest {
     }
 
     @Test
-    void itShouldBeAbleToLoginWithValidUser() {
-        RequestAuthUserDTO validRequestAuthUserDTO = new RequestAuthUserDTO(
-                validUsername,
-                validPassword
-        );
-
+    void itShouldBeAbleGetUserGivenValidCredentials() {
         Optional<User> user = authService.getUserGivenCredentials(validRequestAuthUserDTO);
         assertEquals(true, user.isPresent());
         assertUsersAreEqual(validUser, user.get());
     }
 
     @Test
-    void itShouldNotBeAbleToLoginWithInvalidPassword() {
+    void itShouldNotBeAbleToGetUserGivenInvalidPassword() {
         RequestAuthUserDTO invalidRequestAuthUserDTO = new RequestAuthUserDTO(
                 validUsername,
-                "invalidPassword"
+                invalidPassword
         );
         Optional<User> user = authService.getUserGivenCredentials(invalidRequestAuthUserDTO);
         assertEquals(false, user.isPresent());
     }
 
     @Test
-    void itShouldNotBeAbleToLoginWithInvalidUsername() {
+    void itShouldNotBeAbleToGetUserGivenInvalidUsername() {
         RequestAuthUserDTO invalidRequestAuthUserDTO = new RequestAuthUserDTO(
                 invalidUsername,
                 validPassword
         );
         Optional<User> user = authService.getUserGivenCredentials(invalidRequestAuthUserDTO);
         assertEquals(false, user.isPresent());
+    }
+
+    @Test
+    void itShouldBeAbleToGetJwtTokenGivenValidUser() {
+        Optional<ResponseAuthUserDTO> responseAuthUserDTO = authService.login(validRequestAuthUserDTO);
+        assertEquals(true, responseAuthUserDTO.isPresent());
+        assertEquals(validToken, responseAuthUserDTO.get().token());
+        assertEquals(expiresIn, responseAuthUserDTO.get().expiresIn());
+        assertEquals(tokenType, responseAuthUserDTO.get().tokenType());
+    }
+
+    @Test
+    void itShouldNotBeAbleToGetJwtTokenGivenInvalidUsername() {
+        RequestAuthUserDTO invalidRequestAuthUserDTO = new RequestAuthUserDTO(
+                invalidUsername,
+                validPassword
+        );
+        Optional<ResponseAuthUserDTO> responseAuthUserDTO = authService.login(invalidRequestAuthUserDTO);
+        assertEquals(false, responseAuthUserDTO.isPresent());
+    }
+
+    @Test
+    void itShouldNotBeAbleToGetJwtTokenGivenInvalidPassword() {
+        RequestAuthUserDTO invalidRequestAuthUserDTO = new RequestAuthUserDTO(
+                validUsername,
+                invalidPassword
+        );
+        Optional<ResponseAuthUserDTO> responseAuthUserDTO = authService.login(invalidRequestAuthUserDTO);
+        assertEquals(false, responseAuthUserDTO.isPresent());
     }
 }

--- a/src/test/java/com/mandacarubroker/service/AuthServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.mandacarubroker.domain.auth.RequestAuthUserDTO;
 import com.mandacarubroker.domain.user.RequestUserDTO;
 import com.mandacarubroker.domain.user.User;
 import com.mandacarubroker.domain.user.UserRepository;
+import com.mandacarubroker.security.SecuritySecretsMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -44,10 +45,13 @@ class AuthServiceTest {
 
     @BeforeEach
     void setUp() {
+        SecuritySecretsMock.mockStatic();
+
         userRepository = Mockito.mock(UserRepository.class);
         validUser = new User(validRequestUserDTO);
         Mockito.when(userRepository.findByUsername(validUsername)).thenReturn(validUser);
         Mockito.when(userRepository.findByUsername(invalidUsername)).thenReturn(null);
+
         authService = new AuthService(userRepository);
     }
 
@@ -68,7 +72,7 @@ class AuthServiceTest {
                 validPassword
         );
 
-        Optional<User> user = authService.login(validRequestAuthUserDTO);
+        Optional<User> user = authService.getUserGivenCredentials(validRequestAuthUserDTO);
         assertEquals(true, user.isPresent());
         assertUsersAreEqual(validUser, user.get());
     }
@@ -79,7 +83,7 @@ class AuthServiceTest {
                 validUsername,
                 "invalidPassword"
         );
-        Optional<User> user = authService.login(invalidRequestAuthUserDTO);
+        Optional<User> user = authService.getUserGivenCredentials(invalidRequestAuthUserDTO);
         assertEquals(false, user.isPresent());
     }
 
@@ -89,7 +93,7 @@ class AuthServiceTest {
                 invalidUsername,
                 validPassword
         );
-        Optional<User> user = authService.login(invalidRequestAuthUserDTO);
+        Optional<User> user = authService.getUserGivenCredentials(invalidRequestAuthUserDTO);
         assertEquals(false, user.isPresent());
     }
 }


### PR DESCRIPTION
## Issue
Esse PR estabiliza as rotas de login e permite a geração de um Token JWT após o login.

## Proposta deste PR
* Gerar token JWT após o login

## Impactos deste PR
* Agora ao logar em `/auth/login`, a resposta é um token JWT
* Criação do TokenService
* Criação de uma classe SecuritySecrets que centraliza segredos de segurança que vem das variáveis de ambiente. 

## Evidências de teste

<img width="1283" alt="Screenshot 2024-02-29 at 15 16 39" src="https://github.com/izaiasmachado/mandacarubroker/assets/47287096/ae6be4cf-5381-4498-a730-abc487b54ec4">

Foram alterados os testes do AuthController para refletir o novo comportamento e escritos mais testes unitários para avaliar o comportamento do AuthService. Nesses testes, são Mockadas as classes SecuritySecrets, TokenService e PasswordHashingService.

<img width="622" alt="Screenshot 2024-02-29 at 15 13 08" src="https://github.com/izaiasmachado/mandacarubroker/assets/47287096/3b75bf70-1a9b-4118-83ff-fc0ce1869845">
