### PR TITLE
feat: list stocks owned

### DIFF
--- a/src/main/java/com/mandacarubroker/controller/AuthController.java
+++ b/src/main/java/com/mandacarubroker/controller/AuthController.java
@@ -3,20 +3,17 @@ package com.mandacarubroker.controller;
 import com.mandacarubroker.domain.auth.RequestAuthUserDTO;
 import com.mandacarubroker.domain.auth.ResponseAuthUserDTO;
 import com.mandacarubroker.domain.user.ResponseUserDTO;
+import com.mandacarubroker.domain.user.User;
 import com.mandacarubroker.service.AuthService;
 import com.mandacarubroker.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Optional;
 
 @RestController
@@ -43,16 +40,8 @@ public class AuthController {
 
     @GetMapping("/me")
     public ResponseEntity<ResponseUserDTO> getCurrentUser() {
-        SecurityContext securityContext = SecurityContextHolder.getContext();
-        Authentication authentication = securityContext.getAuthentication();
-        Object principal = authentication.getPrincipal();
-
-        if (principal instanceof UserDetails) {
-            UserDetails userDetails = (UserDetails) principal;
-            Optional<ResponseUserDTO> user = userService.findByUsername(userDetails.getUsername());
-            return ResponseEntity.ok(user.get());
-        }
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        User user = AuthService.getAuthenticatedUser();
+        ResponseUserDTO responseUserDTO = ResponseUserDTO.fromUser(user);
+        return ResponseEntity.ok(responseUserDTO);
     }
 }

--- a/src/main/java/com/mandacarubroker/controller/PortfolioController.java
+++ b/src/main/java/com/mandacarubroker/controller/PortfolioController.java
@@ -1,0 +1,24 @@
+package com.mandacarubroker.controller;
+
+import com.mandacarubroker.domain.position.ResponseStockOwnershipDTO;
+import com.mandacarubroker.service.PortfolioService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/portfolio")
+public class PortfolioController {
+    private final PortfolioService portfolioService;
+
+    public PortfolioController(final PortfolioService receivedPortfolioService) {
+        this.portfolioService = receivedPortfolioService;
+    }
+
+    @GetMapping
+    public List<ResponseStockOwnershipDTO> getAuthenticatedUserStockPortfolio() {
+        return portfolioService.getAuthenticatedUserStockPortfolio();
+    }
+}

--- a/src/main/java/com/mandacarubroker/domain/position/RequestStockOwnershipDTO.java
+++ b/src/main/java/com/mandacarubroker/domain/position/RequestStockOwnershipDTO.java
@@ -1,0 +1,9 @@
+package com.mandacarubroker.domain.position;
+
+import jakarta.validation.constraints.Positive;
+
+public record RequestStockOwnershipDTO(
+        @Positive(message = "Share amount must be greater than zero")
+        int shares
+) {
+}

--- a/src/main/java/com/mandacarubroker/domain/position/ResponseStockOwnershipDTO.java
+++ b/src/main/java/com/mandacarubroker/domain/position/ResponseStockOwnershipDTO.java
@@ -1,0 +1,21 @@
+package com.mandacarubroker.domain.position;
+
+import com.mandacarubroker.domain.stock.Stock;
+
+public record ResponseStockOwnershipDTO(
+    String id,
+    Stock stock,
+    int totalShares,
+    double positionValue
+) {
+    public static ResponseStockOwnershipDTO fromStockPosition(final StockOwnership stockPosition) {
+        final Stock stock = stockPosition.getStock();
+
+        return new ResponseStockOwnershipDTO(
+            stockPosition.getId(),
+            stock,
+            stockPosition.getShares(),
+            stockPosition.getTotalValue()
+        );
+    }
+}

--- a/src/main/java/com/mandacarubroker/domain/position/StockOwnership.java
+++ b/src/main/java/com/mandacarubroker/domain/position/StockOwnership.java
@@ -1,0 +1,45 @@
+package com.mandacarubroker.domain.position;
+
+import com.mandacarubroker.domain.stock.Stock;
+import com.mandacarubroker.domain.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Table(name = "stock_ownership")
+@Entity(name = "stock_ownership")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class StockOwnership {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+    private int shares;
+    @OneToOne
+    private Stock stock;
+    @OneToOne
+    private User user;
+
+    public StockOwnership(final RequestStockOwnershipDTO requestStockPositionDTO, final Stock receivedStock, final User receivedUser) {
+        this.shares = requestStockPositionDTO.shares();
+        this.stock = receivedStock;
+        this.user = receivedUser;
+    }
+
+    public double getTotalValue() {
+        return shares * stock.getPrice();
+    }
+
+    public Stock getStock() {
+        return stock;
+    }
+}

--- a/src/main/java/com/mandacarubroker/domain/position/StockOwnershipRepository.java
+++ b/src/main/java/com/mandacarubroker/domain/position/StockOwnershipRepository.java
@@ -1,0 +1,9 @@
+package com.mandacarubroker.domain.position;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StockOwnershipRepository extends JpaRepository<StockOwnership, String> {
+    List<StockOwnership> findByUserId(String userId);
+}

--- a/src/main/java/com/mandacarubroker/domain/user/ResponseUserDTO.java
+++ b/src/main/java/com/mandacarubroker/domain/user/ResponseUserDTO.java
@@ -11,5 +11,16 @@ public record ResponseUserDTO(
         LocalDate birthDate,
         double balance
 ) {
+    public static ResponseUserDTO fromUser(final User user) {
+        return new ResponseUserDTO(
+                user.getId(),
+                user.getEmail(),
+                user.getUsername(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getBirthDate(),
+                user.getBalance()
+        );
+    }
 }
 

--- a/src/main/java/com/mandacarubroker/service/AuthService.java
+++ b/src/main/java/com/mandacarubroker/service/AuthService.java
@@ -4,6 +4,9 @@ import com.mandacarubroker.domain.auth.RequestAuthUserDTO;
 import com.mandacarubroker.domain.auth.ResponseAuthUserDTO;
 import com.mandacarubroker.domain.user.User;
 import com.mandacarubroker.domain.user.UserRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -53,5 +56,17 @@ public class AuthService {
         }
 
         return Optional.of(user);
+    }
+
+    public static User getAuthenticatedUser() {
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        Authentication authentication = securityContext.getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("User not authenticated");
+        }
+
+        Object principal = authentication.getPrincipal();
+        return (User) principal;
     }
 }

--- a/src/main/java/com/mandacarubroker/service/PortfolioService.java
+++ b/src/main/java/com/mandacarubroker/service/PortfolioService.java
@@ -1,0 +1,32 @@
+package com.mandacarubroker.service;
+
+import com.mandacarubroker.domain.position.ResponseStockOwnershipDTO;
+import com.mandacarubroker.domain.position.StockOwnership;
+import com.mandacarubroker.domain.position.StockOwnershipRepository;
+import com.mandacarubroker.domain.user.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PortfolioService {
+    private final StockOwnershipRepository stockPositionRepository;
+
+    public PortfolioService(final StockOwnershipRepository receivedStockPositionRepository) {
+        this.stockPositionRepository = receivedStockPositionRepository;
+    }
+
+    public List<ResponseStockOwnershipDTO> getAuthenticatedUserStockPortfolio() {
+        User user = AuthService.getAuthenticatedUser();
+        String userId = user.getId();
+        return getPortfolioByUserId(userId);
+    }
+
+    public List<ResponseStockOwnershipDTO> getPortfolioByUserId(final String userId) {
+        List<StockOwnership> stockPositions = stockPositionRepository.findByUserId(userId);
+
+        return stockPositions.stream()
+            .map(ResponseStockOwnershipDTO::fromStockPosition)
+            .toList();
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -20,3 +20,10 @@ INSERT INTO users (id, email, username, password, first_name, last_name, birth_d
 VALUES
     ('b2d13c5a-3df0-4673-b3e6-49244f395ac7', 'admin@example.com', 'admin', '$2a$10$oUmo9dGdjnbdWeYlq7tsNuZo/r.pwI6T8JbEu2bp26Y5Zg7uzrKMy', 'Ademir', 'Ademilson', '2002-01-01', 777.7, 'ADMIN')
     ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO stock_ownership (id, stock_id, user_id, shares)
+VALUES
+    ('b3d13c5a-3df0-4673-b3e6-49244f395ac9', 'b2d13c5a-3df0-4673-b3e6-49244f395ac9', 'b2d13c5a-3df0-4673-b3e6-49244f395ac7', 10),
+    ('b3d13c5a-3df0-4673-b3e6-49244f395ad9', 'b2d13c5a-3df0-4673-b3e6-49244f395ad9', 'b2d13c5a-3df0-4673-b3e6-49244f395ac7', 20)
+    ON CONFLICT (id) DO NOTHING;
+

--- a/src/main/resources/db/migration/V4__create-table-stock-ownership.sql
+++ b/src/main/resources/db/migration/V4__create-table-stock-ownership.sql
@@ -1,0 +1,8 @@
+CREATE TABLE stock_ownership (
+    id VARCHAR PRIMARY KEY,
+    shares INT NOT NULL,
+    stock_id VARCHAR NOT NULL,
+    user_id VARCHAR NOT NULL,
+    FOREIGN KEY (stock_id) REFERENCES stock(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/test/java/com/mandacarubroker/controller/PortfolioControllerTest.java
+++ b/src/test/java/com/mandacarubroker/controller/PortfolioControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
 
+import static com.mandacarubroker.domain.stock.StockUtils.assertStocksAreEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PortfolioControllerTest {
@@ -25,13 +26,6 @@ public class PortfolioControllerTest {
             new ResponseStockOwnershipDTO("apple-stock-id", appleStock, 100, 10000.00),
             new ResponseStockOwnershipDTO("google-stock-id", googleStock, 200, 400000.00)
     );
-
-    private void assertStocksAreEqual(final Stock expectedStock, final Stock actualStock) {
-        assertEquals(expectedStock.getId(), actualStock.getId());
-        assertEquals(expectedStock.getSymbol(), actualStock.getSymbol());
-        assertEquals(expectedStock.getCompanyName(), actualStock.getCompanyName());
-        assertEquals(expectedStock.getPrice(), actualStock.getPrice());
-    }
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/mandacarubroker/controller/PortfolioControllerTest.java
+++ b/src/test/java/com/mandacarubroker/controller/PortfolioControllerTest.java
@@ -1,0 +1,64 @@
+package com.mandacarubroker.controller;
+
+import com.mandacarubroker.domain.position.ResponseStockOwnershipDTO;
+import com.mandacarubroker.domain.stock.RequestStockDTO;
+import com.mandacarubroker.domain.stock.Stock;
+import com.mandacarubroker.security.SecuritySecretsMock;
+import com.mandacarubroker.service.PortfolioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PortfolioControllerTest {
+    @MockBean
+    private PortfolioService portfolioService;
+    private final RequestStockDTO requestAppleStock = new RequestStockDTO("AAPL", "Apple Inc", 100.00);
+    private final RequestStockDTO requestGoogleStock = new RequestStockDTO("GOOGL", "Alphabet Inc", 2000.00);
+    private final Stock appleStock = new Stock(requestAppleStock);
+    private final Stock googleStock = new Stock(requestGoogleStock);
+    private final List<ResponseStockOwnershipDTO> storedStockPortfolio = List.of(
+            new ResponseStockOwnershipDTO("apple-stock-id", appleStock, 100, 10000.00),
+            new ResponseStockOwnershipDTO("google-stock-id", googleStock, 200, 400000.00)
+    );
+
+    private void assertStocksAreEqual(final Stock expectedStock, final Stock actualStock) {
+        assertEquals(expectedStock.getId(), actualStock.getId());
+        assertEquals(expectedStock.getSymbol(), actualStock.getSymbol());
+        assertEquals(expectedStock.getCompanyName(), actualStock.getCompanyName());
+        assertEquals(expectedStock.getPrice(), actualStock.getPrice());
+    }
+
+    @BeforeEach
+    void setUp() {
+        SecuritySecretsMock.mockStatic();
+
+        portfolioService = Mockito.mock(PortfolioService.class);
+
+        Mockito.when(portfolioService.getAuthenticatedUserStockPortfolio()).thenReturn(storedStockPortfolio);
+    }
+
+    @Test
+    void itShouldReturnTheAuthenticatedUserStockPortfolio() {
+        List<ResponseStockOwnershipDTO> expectedStockPortfolio = storedStockPortfolio;
+        List<ResponseStockOwnershipDTO> actualStockPortfolio = portfolioService.getAuthenticatedUserStockPortfolio();
+
+        assertEquals(expectedStockPortfolio.size(), actualStockPortfolio.size());
+
+        for (int i = 0; i < expectedStockPortfolio.size(); i++) {
+            ResponseStockOwnershipDTO expectedStockOwnership = expectedStockPortfolio.get(i);
+            ResponseStockOwnershipDTO actualStockOwnership = actualStockPortfolio.get(i);
+            Stock expectedStock = expectedStockOwnership.stock();
+            Stock actualStock = actualStockOwnership.stock();
+
+            assertEquals(expectedStockOwnership.id(), actualStockOwnership.id());
+            assertEquals(expectedStockOwnership.totalShares(), actualStockOwnership.totalShares());
+            assertEquals(expectedStockOwnership.positionValue(), actualStockOwnership.positionValue());
+            assertStocksAreEqual(expectedStock, actualStock);
+        }
+    }
+}

--- a/src/test/java/com/mandacarubroker/domain/stock/StockUtils.java
+++ b/src/test/java/com/mandacarubroker/domain/stock/StockUtils.java
@@ -1,0 +1,15 @@
+package com.mandacarubroker.domain.stock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class StockUtils {
+    private StockUtils() {
+    }
+
+    public static void assertStocksAreEqual(final Stock expectedStock, final Stock actualStock) {
+        assertEquals(expectedStock.getId(), actualStock.getId());
+        assertEquals(expectedStock.getSymbol(), actualStock.getSymbol());
+        assertEquals(expectedStock.getCompanyName(), actualStock.getCompanyName());
+        assertEquals(expectedStock.getPrice(), actualStock.getPrice());
+    }
+}

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.mandacarubroker.domain.stock.StockUtils.assertStocksAreEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mockStatic;
 
@@ -70,7 +71,7 @@ public class PortfolioServiceTest {
         List<ResponseStockOwnershipDTO> stockPortfolio = portfolioService.getAuthenticatedUserStockPortfolio();
 
         for (int i = 0; i < stockPortfolio.size(); i++) {
-            assertEquals(stockPortfolio.get(i).stock(), this.storedStockPortfolio.get(i).stock());
+            assertStocksAreEqual(stockPortfolio.get(i).stock(), this.storedStockPortfolio.get(i).stock());
             assertEquals(stockPortfolio.get(i).totalShares(), this.storedStockPortfolio.get(i).totalShares());
             assertEquals(stockPortfolio.get(i).positionValue(), this.storedStockPortfolio.get(i).positionValue());
         }
@@ -81,7 +82,7 @@ public class PortfolioServiceTest {
         List<ResponseStockOwnershipDTO> stockPortfolio = portfolioService.getPortfolioByUserId(validUser.getId());
 
         for (int i = 0; i < stockPortfolio.size(); i++) {
-            assertEquals(stockPortfolio.get(i).stock(), this.storedStockPortfolio.get(i).stock());
+            assertStocksAreEqual(stockPortfolio.get(i).stock(), this.storedStockPortfolio.get(i).stock());
             assertEquals(stockPortfolio.get(i).totalShares(), this.storedStockPortfolio.get(i).totalShares());
             assertEquals(stockPortfolio.get(i).positionValue(), this.storedStockPortfolio.get(i).positionValue());
         }

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -26,7 +26,6 @@ public class PortfolioServiceTest {
 
     private PortfolioService portfolioService;
 
-
     private final RequestUserDTO validRequestUserDTO = new RequestUserDTO(
             "marcosloiola@yahoo.com",
             "Marcos22",

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -1,0 +1,79 @@
+package com.mandacarubroker.service;
+
+import com.mandacarubroker.domain.position.RequestStockOwnershipDTO;
+import com.mandacarubroker.domain.position.ResponseStockOwnershipDTO;
+import com.mandacarubroker.domain.position.StockOwnership;
+import com.mandacarubroker.domain.position.StockOwnershipRepository;
+import com.mandacarubroker.domain.stock.RequestStockDTO;
+import com.mandacarubroker.domain.stock.Stock;
+import com.mandacarubroker.domain.user.RequestUserDTO;
+import com.mandacarubroker.domain.user.User;
+import com.mandacarubroker.security.SecuritySecretsMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+public class PortfolioServiceTest {
+    @MockBean
+    private StockOwnershipRepository stockPositionRepository;
+
+    private PortfolioService portfolioService;
+
+
+    private final RequestUserDTO validRequestUserDTO = new RequestUserDTO(
+            "marcosloiola@yahoo.com",
+            "Marcos22",
+            "passmarco123",
+            "Marcos",
+            "Loiola",
+            LocalDate.of(2002, 2, 26),
+            0.25
+    );
+
+    private final User validUser = new User(validRequestUserDTO);
+
+    private final RequestStockDTO requestAppleStock = new RequestStockDTO("AAPL", "Apple Inc", 100.00);
+    private final RequestStockDTO requestGoogleStock = new RequestStockDTO("GOOGL", "Alphabet Inc", 2000.00);
+    private final Stock appleStock = new Stock(requestAppleStock);
+    private final Stock googleStock = new Stock(requestGoogleStock);
+    private final List<ResponseStockOwnershipDTO> storedStockPortfolio = List.of(
+            new ResponseStockOwnershipDTO("apple-stock-id", appleStock, 100, 10000.00),
+            new ResponseStockOwnershipDTO("google-stock-id", googleStock, 200, 400000.00)
+    );
+
+    private final List<StockOwnership> givenStockOwnerships = List.of(
+            new StockOwnership(new RequestStockOwnershipDTO(100), appleStock, validUser),
+            new StockOwnership(new RequestStockOwnershipDTO(200), googleStock, validUser)
+    );
+
+    @BeforeEach
+    void setUp() {
+        SecuritySecretsMock.mockStatic();
+
+        mockStatic(AuthService.class);
+        Mockito.when(AuthService.getAuthenticatedUser()).thenReturn(validUser);
+
+        stockPositionRepository = Mockito.mock(StockOwnershipRepository.class);
+        Mockito.when(stockPositionRepository.findByUserId(validUser.getId())).thenReturn(givenStockOwnerships);
+
+        portfolioService = new PortfolioService(stockPositionRepository);
+    }
+
+    @Test
+    void itShouldReturnTheStockPortfolioOfTheAuthenticatedUser() {
+        List<ResponseStockOwnershipDTO> stockPortfolio = portfolioService.getAuthenticatedUserStockPortfolio();
+
+        for (int i = 0; i < stockPortfolio.size(); i++) {
+            assertEquals(stockPortfolio.get(i).stock(), this.storedStockPortfolio.get(i).stock());
+            assertEquals(stockPortfolio.get(i).totalShares(), this.storedStockPortfolio.get(i).totalShares());
+            assertEquals(stockPortfolio.get(i).positionValue(), this.storedStockPortfolio.get(i).positionValue());
+        }
+    }
+}

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -57,9 +57,6 @@ public class PortfolioServiceTest {
     void setUp() {
         SecuritySecretsMock.mockStatic();
 
-        mockStatic(AuthService.class);
-        Mockito.when(AuthService.getAuthenticatedUser()).thenReturn(validUser);
-
         stockPositionRepository = Mockito.mock(StockOwnershipRepository.class);
         Mockito.when(stockPositionRepository.findByUserId(validUser.getId())).thenReturn(givenStockOwnerships);
 
@@ -68,7 +65,21 @@ public class PortfolioServiceTest {
 
     @Test
     void itShouldReturnTheStockPortfolioOfTheAuthenticatedUser() {
+        mockStatic(AuthService.class);
+        Mockito.when(AuthService.getAuthenticatedUser()).thenReturn(validUser);
+
         List<ResponseStockOwnershipDTO> stockPortfolio = portfolioService.getAuthenticatedUserStockPortfolio();
+
+        for (int i = 0; i < stockPortfolio.size(); i++) {
+            assertEquals(stockPortfolio.get(i).stock(), this.storedStockPortfolio.get(i).stock());
+            assertEquals(stockPortfolio.get(i).totalShares(), this.storedStockPortfolio.get(i).totalShares());
+            assertEquals(stockPortfolio.get(i).positionValue(), this.storedStockPortfolio.get(i).positionValue());
+        }
+    }
+
+    @Test
+    void itShouldBeAbleToGetStockPortfolioByUserId() {
+        List<ResponseStockOwnershipDTO> stockPortfolio = portfolioService.getPortfolioByUserId(validUser.getId());
 
         for (int i = 0; i < stockPortfolio.size(); i++) {
             assertEquals(stockPortfolio.get(i).stock(), this.storedStockPortfolio.get(i).stock());


### PR DESCRIPTION
## Issue
Como aparece no descritivo do trabalho, uma das formas de aumentar ou reduzir o `balance` é comprando ou vendendo ações. Se é possível vender as ações, é necessário saber quais são as ações que o usuário tem.

É importante dizer que nesse PR não foi implementada rotas para comprar ou vender ações, somente listar.

## Proposta deste PR
* Possibilidade do usuário ter ações

## Impactos deste PR
* Implementada a tabela `stocks_owned` que relaciona usuário, ação e quantidade
* Rota `/portfolio` que lista as ações do usuário
 
## Evidências de teste

<img width="1284" alt="Screenshot 2024-03-03 at 09 55 52" src="https://github.com/izaiasmachado/mandacarubroker/assets/47287096/980ae311-8c4b-4db9-a68f-11740f99656c">

<img width="483" alt="Screenshot 2024-03-03 at 09 52 19" src="https://github.com/izaiasmachado/mandacarubroker/assets/47287096/24e60d89-145f-464c-ac86-bfa88ac62fb1">

<img width="480" alt="Screenshot 2024-03-03 at 09 52 03" src="https://github.com/izaiasmachado/mandacarubroker/assets/47287096/6f55bb7b-e11f-4c56-a361-690ebdd0335b">

