### PR TITLE
chore: add jacoco coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,9 +56,13 @@ jobs:
 
       - name: SonarCloud Scan
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=mandacaru-broker_mandacaru-broker-api
+
+      - name: Sonar Cloud Coverage
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn sonar:sonar -Pcoverage -Dsonar.projectKey=mandacaru-broker_mandacaru-broker-api
 
       - name: Stop Docker
         run: docker-compose down

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,30 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.7</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.7</version>
+				<version>0.8.11</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
## Issue

Não aparecia a porcentagem de cobertura de testes no SonarCloud, porém isso é uma métrica importante de Qualidade de Software

## Proposta deste PR
* Instalar Jacoco para ter Coverage no SonarCloud

## Impactos deste PR
* Agora é possível gerar relatórios do Jacoco executando o comando `mvn jacoco:report`
* A porcentagem de Coverage agora aparece no SonarCloud

## Evidências de teste

### Execução do Jacoco Local

1. Execute `mvn clean install`
2. Execute `mvn jacoco:report`
3. Em `target/site/jacoco/index.html` pode ser encontrado o relatório de cobertura gerado
![Screenshot 2024-03-04 at 21 30 09](https://github.com/izaiasmachado/mandacarubroker/assets/47287096/f27da6a6-da5c-44e3-8b0c-5542dbdb6175)

### Coverage no SonarCloud

Agora está aparecendo o estimated Coverage, que não aparecia em outros PRs.

![Screenshot 2024-03-04 at 21 30 26](https://github.com/izaiasmachado/mandacarubroker/assets/47287096/7f51f002-8843-4eb4-a0d3-d579098e4ae3)

