### PR TITLE
refactor: portfolio

### DIFF
--- a/src/main/java/com/mandacarubroker/controller/PortfolioController.java
+++ b/src/main/java/com/mandacarubroker/controller/PortfolioController.java
@@ -13,13 +13,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
-import java.util.Optional;
 
 @Tag(name = "Portfólio de Ativos", description = "Operações relacionadas com portfólios de ativos. User role: user")
 @RestController
@@ -47,7 +44,8 @@ public class PortfolioController {
     @PostMapping("/stock/{stockId}/buy")
     public ResponseEntity<ResponseStockOwnershipDTO> buyStock(
             @PathVariable final String stockId,
-            @RequestBody @Valid final RequestStockOwnershipDTO shares) {
+            @RequestBody @Valid final RequestStockOwnershipDTO shares
+    ) {
         ResponseStockOwnershipDTO stockPosition = portfolioService.buyStock(stockId, shares);
         return ResponseEntity.ok(stockPosition);
     }
@@ -59,7 +57,8 @@ public class PortfolioController {
     @PostMapping("/stock/{stockId}/sell")
     public ResponseEntity<ResponseStockOwnershipDTO> sellStock(
             @PathVariable final String stockId,
-            @RequestBody @Valid final RequestStockOwnershipDTO shares) {
+            @RequestBody @Valid final RequestStockOwnershipDTO shares
+    ) {
         ResponseStockOwnershipDTO stockPosition = portfolioService.sellStock(stockId, shares);
         return ResponseEntity.ok(stockPosition);
     }
@@ -70,14 +69,8 @@ public class PortfolioController {
             @ApiResponse(responseCode = "404", description = "Ação não encontrada")
     })
     @GetMapping("/stock/{stockId}")
-    public ResponseStockOwnershipDTO getStockPositionById(@PathVariable final String stockId) {
-        Optional<ResponseStockOwnershipDTO> stockPosition = portfolioService
-                .getAuthenticatedUserStockOwnershipByStockId(stockId);
-
-        if (stockPosition.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Stock ownership not found");
-        }
-
-        return stockPosition.get();
+    public ResponseEntity<ResponseStockOwnershipDTO> getStockPositionById(@PathVariable final String stockId) {
+        ResponseStockOwnershipDTO stockPosition = portfolioService.getAuthenticatedUserStockOwnershipByStockId(stockId);
+        return ResponseEntity.ok(stockPosition);
     }
 }

--- a/src/main/java/com/mandacarubroker/domain/position/ResponseStockOwnershipDTO.java
+++ b/src/main/java/com/mandacarubroker/domain/position/ResponseStockOwnershipDTO.java
@@ -7,13 +7,13 @@ public record ResponseStockOwnershipDTO(
         ResponseStockDTO stock,
         int totalShares,
         double positionValue) {
-    public static ResponseStockOwnershipDTO fromStockPosition(final StockOwnership stockPosition) {
-        final Stock stock = stockPosition.getStock();
+    public static ResponseStockOwnershipDTO fromStockOwnership(final StockOwnership stockOwnership) {
+        final Stock stock = stockOwnership.getStock();
 
         return new ResponseStockOwnershipDTO(
                 ResponseStockDTO.fromStock(stock),
-                stockPosition.getShares(),
-                stockPosition.getTotalValue());
+                stockOwnership.getShares(),
+                stockOwnership.getTotalValue());
     }
 
     public static ResponseStockOwnershipDTO fromStock(final Stock stock) {

--- a/src/main/java/com/mandacarubroker/domain/position/StockOwnership.java
+++ b/src/main/java/com/mandacarubroker/domain/position/StockOwnership.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import com.mandacarubroker.exceptions.IllegalArgumentException;
 
 @Table(name = "stock_ownership")
 @Entity(name = "stock_ownership")

--- a/src/main/java/com/mandacarubroker/domain/position/StockOwnership.java
+++ b/src/main/java/com/mandacarubroker/domain/position/StockOwnership.java
@@ -42,4 +42,24 @@ public class StockOwnership {
     public Stock getStock() {
         return stock;
     }
+
+    public void buyShares(final int sharesToBuy) {
+        if (sharesToBuy < 0) {
+            throw new IllegalArgumentException("Invalid number of shares");
+        }
+
+        shares += sharesToBuy;
+    }
+
+    public void sellShares(final int sharesToSell) {
+        if (sharesToSell < 0) {
+            throw new IllegalArgumentException("Invalid number of shares");
+        }
+
+        if (shares < sharesToSell) {
+            throw new IllegalArgumentException("Insufficient shares");
+        }
+
+        shares -= sharesToSell;
+    }
 }

--- a/src/main/java/com/mandacarubroker/domain/user/User.java
+++ b/src/main/java/com/mandacarubroker/domain/user/User.java
@@ -15,6 +15,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import com.mandacarubroker.exceptions.IllegalArgumentException;
 
 import java.time.LocalDate;
 import java.util.Collection;

--- a/src/main/java/com/mandacarubroker/domain/user/User.java
+++ b/src/main/java/com/mandacarubroker/domain/user/User.java
@@ -59,17 +59,17 @@ public class User implements UserDetails {
 
     public void deposit(final double amount) {
         if (amount <= 0) {
-            throw new IllegalArgumentException("The deposit amount must be greater than zero.");
+            throw new IllegalArgumentException("The amount must be greater than zero.");
         }
         this.balance += amount;
     }
 
     public void withdraw(final double amount) {
         if (amount <= 0) {
-            throw new IllegalArgumentException("The withdrawal amount must be greater than zero.");
+            throw new IllegalArgumentException("The amount must be greater than zero.");
         }
         if (amount > balance) {
-            throw new IllegalArgumentException("Insufficient balance for withdrawal.");
+            throw new IllegalArgumentException("Insufficient balance.");
         }
         this.balance -= amount;
     }

--- a/src/main/java/com/mandacarubroker/exceptions/ErrorResponse.java
+++ b/src/main/java/com/mandacarubroker/exceptions/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.mandacarubroker.exceptions;
+
+public record ErrorResponse(
+        int status,
+        String message
+) {
+    public static ErrorResponse fromException(final HttpStatusMessageProvider ex) {
+        return new ErrorResponse(ex.getHttpStatus().value(), ex.getMessage());
+    }
+}

--- a/src/main/java/com/mandacarubroker/exceptions/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/mandacarubroker/exceptions/GlobalControllerExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.mandacarubroker.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+class GlobalControllerExceptionHandler {
+    @ExceptionHandler(HttpStatusMessageProvider.class)
+    public ResponseEntity<Object> handleHttpStatusMessageProviderException(final HttpStatusMessageProvider ex) {
+        HttpStatus status = ex.getHttpStatus();
+        String message = ex.getMessage();
+        ErrorResponse errorResponse = new ErrorResponse(status.value(), message);
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+}

--- a/src/main/java/com/mandacarubroker/exceptions/HttpStatusMessageProvider.java
+++ b/src/main/java/com/mandacarubroker/exceptions/HttpStatusMessageProvider.java
@@ -1,0 +1,17 @@
+package com.mandacarubroker.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class HttpStatusMessageProvider extends RuntimeException {
+    private final String message;
+
+    public HttpStatusMessageProvider(final String receivedMessage) {
+        this.message = receivedMessage;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public abstract HttpStatus getHttpStatus();
+}

--- a/src/main/java/com/mandacarubroker/exceptions/HttpStatusMessageProvider.java
+++ b/src/main/java/com/mandacarubroker/exceptions/HttpStatusMessageProvider.java
@@ -5,10 +5,11 @@ import org.springframework.http.HttpStatus;
 public abstract class HttpStatusMessageProvider extends RuntimeException {
     private final String message;
 
-    public HttpStatusMessageProvider(final String receivedMessage) {
+    protected HttpStatusMessageProvider(final String receivedMessage) {
         this.message = receivedMessage;
     }
 
+    @Override
     public String getMessage() {
         return message;
     }

--- a/src/main/java/com/mandacarubroker/exceptions/IllegalArgumentException.java
+++ b/src/main/java/com/mandacarubroker/exceptions/IllegalArgumentException.java
@@ -1,0 +1,13 @@
+package com.mandacarubroker.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class IllegalArgumentException extends HttpStatusMessageProvider {
+    public IllegalArgumentException(final String receivedMessage) {
+        super(receivedMessage);
+    }
+
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/com/mandacarubroker/exceptions/NotFoundException.java
+++ b/src/main/java/com/mandacarubroker/exceptions/NotFoundException.java
@@ -1,0 +1,13 @@
+package com.mandacarubroker.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends HttpStatusMessageProvider {
+    public NotFoundException(final String receivedMessage) {
+        super(receivedMessage);
+    }
+
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/com/mandacarubroker/service/PortfolioService.java
+++ b/src/main/java/com/mandacarubroker/service/PortfolioService.java
@@ -26,16 +26,15 @@ public class PortfolioService {
         this.userRepository = recievedUserRepository;
     }
 
-    public Optional<ResponseStockOwnershipDTO> getAuthenticatedUserStockOwnershipByStockId(final String stockId) {
+    public ResponseStockOwnershipDTO getAuthenticatedUserStockOwnershipByStockId(final String stockId) {
         User user = AuthService.getAuthenticatedUser();
         return getStockOwnershipByStockId(user, stockId);
     }
 
-    public Optional<ResponseStockOwnershipDTO> getStockOwnershipByStockId(final User user, final String stockId) {
+    public ResponseStockOwnershipDTO getStockOwnershipByStockId(final User user, final String stockId) {
         Stock stock = getStock(stockId);
         StockOwnership stockOwnership = getStockOwnership(user, stock);
-        ResponseStockOwnershipDTO responseStockOwnershipDTO = ResponseStockOwnershipDTO.fromStockOwnership(stockOwnership);
-        return Optional.of(responseStockOwnershipDTO);
+        return ResponseStockOwnershipDTO.fromStockOwnership(stockOwnership);
     }
 
     private Stock getStock(final String stockId) {

--- a/src/main/java/com/mandacarubroker/service/PortfolioService.java
+++ b/src/main/java/com/mandacarubroker/service/PortfolioService.java
@@ -40,21 +40,14 @@ public class PortfolioService {
     }
 
     public Optional<ResponseStockOwnershipDTO> getStockOwnershipByStockId(final User user, final String stockId) {
-        String userId = user.getId();
-        Stock stock = stockRepository.findById(stockId).orElse(null);
+        Optional<Stock> stock = stockRepository.findById(stockId);
 
-        if (stock == null) {
+        if (stock.isEmpty()) {
             return Optional.empty();
         }
 
-        StockOwnership stockPosition = stockOwnershipRepository.findByUserIdAndStockId(userId, stockId);
-
-        if (stockPosition == null) {
-            return Optional.of(ResponseStockOwnershipDTO.fromStock(stock));
-        }
-
-        ResponseStockOwnershipDTO responseStockOwnershipDTO = ResponseStockOwnershipDTO
-                .fromStockOwnership(stockPosition);
+        StockOwnership stockOwnership = getStockOwnership(user, stock.get());
+        ResponseStockOwnershipDTO responseStockOwnershipDTO = ResponseStockOwnershipDTO.fromStockOwnership(stockOwnership);
         return Optional.of(responseStockOwnershipDTO);
     }
 

--- a/src/main/java/com/mandacarubroker/service/PortfolioService.java
+++ b/src/main/java/com/mandacarubroker/service/PortfolioService.java
@@ -52,8 +52,7 @@ public class PortfolioService {
 
         if (stockOwnership == null) {
             RequestStockOwnershipDTO requestStockOwnershipDTO = new RequestStockOwnershipDTO(0);
-            StockOwnership newStockOwnership = new StockOwnership(requestStockOwnershipDTO, stock, user);
-            return newStockOwnership;
+            return new StockOwnership(requestStockOwnershipDTO, stock, user);
         }
 
         return stockOwnership;
@@ -65,8 +64,7 @@ public class PortfolioService {
             return stockOwnership;
         }
 
-        StockOwnership updatedStockOwnership = stockOwnershipRepository.save(stockOwnership);
-        return updatedStockOwnership;
+        return stockOwnershipRepository.save(stockOwnership);
     }
 
     public List<ResponseStockOwnershipDTO> getAuthenticatedUserStockPortfolio() {

--- a/src/test/java/com/mandacarubroker/domain/position/StockOwnershipTest.java
+++ b/src/test/java/com/mandacarubroker/domain/position/StockOwnershipTest.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class StockOwnershipTest {
+class StockOwnershipTest {
     private final RequestUserDTO requestUserDTO = new RequestUserDTO(
             "marcosloiola@yahoo.com",
             "Marcos22",

--- a/src/test/java/com/mandacarubroker/domain/position/StockOwnershipTest.java
+++ b/src/test/java/com/mandacarubroker/domain/position/StockOwnershipTest.java
@@ -1,0 +1,102 @@
+package com.mandacarubroker.domain.position;
+
+import com.mandacarubroker.domain.stock.Stock;
+import com.mandacarubroker.domain.user.RequestUserDTO;
+import com.mandacarubroker.domain.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.mandacarubroker.exceptions.IllegalArgumentException;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class StockOwnershipTest {
+    private final RequestUserDTO requestUserDTO = new RequestUserDTO(
+            "marcosloiola@yahoo.com",
+            "Marcos22",
+            "passmarco123",
+            "Marcos",
+            "Loiola",
+            LocalDate.of(2002, 2, 26),
+            0
+    );
+    private final User validUser = new User(requestUserDTO);
+    private final RequestStockOwnershipDTO requestStockOwnershipDTO = new RequestStockOwnershipDTO(10);
+    private final Stock validStock = new Stock("stock-id", "symbol", "companyName", 100.0);
+    private StockOwnership stockOwnership;
+
+    @BeforeEach
+    void setUp() {
+        stockOwnership = new StockOwnership(requestStockOwnershipDTO, validStock, validUser);
+    }
+
+    @Test
+    void itShouldBeAbleToBuyStocks() {
+        final int sharesToBuy = 10;
+        final int expectedShares = stockOwnership.getShares() + sharesToBuy;
+
+        stockOwnership.buyShares(sharesToBuy);
+        assertEquals(expectedShares, stockOwnership.getShares());
+    }
+
+    @Test
+    void itShouldNotBeAbleToBuyZeroShares() {
+        final int sharesToBuy = 0;
+        final int expectedShares = stockOwnership.getShares();
+        assertEquals(expectedShares, stockOwnership.getShares());
+    }
+
+    @Test
+    void itShouldNotBeAbleToBuyNegativeShares() {
+        final int sharesToBuy = -10;
+        final int expectedShares = stockOwnership.getShares();
+
+        assertThrows(IllegalArgumentException.class, () -> stockOwnership.buyShares(sharesToBuy));
+
+        assertEquals(expectedShares, stockOwnership.getShares());
+    }
+
+    @Test
+    void itShouldBeAbleToSellStocks() {
+        final int sharesToSell = 10;
+        final int expectedShares = stockOwnership.getShares() - sharesToSell;
+
+        stockOwnership.sellShares(sharesToSell);
+        assertEquals(expectedShares, stockOwnership.getShares());
+    }
+
+    @Test
+    void itShouldNotBeAbleToSellZeroShares() {
+        final int sharesToSell = 0;
+        final int expectedShares = stockOwnership.getShares();
+        assertEquals(expectedShares, stockOwnership.getShares());
+    }
+
+    @Test
+    void itShouldNotBeAbleToSellNegativeShares() {
+        final int sharesToSell = -10;
+        final int expectedShares = stockOwnership.getShares();
+
+        assertThrows(IllegalArgumentException.class, () -> stockOwnership.sellShares(sharesToSell));
+
+        assertEquals(expectedShares, stockOwnership.getShares());
+    }
+
+    @Test
+    void itShouldNotBeAbleToSellMoreSharesThanOwned() {
+        final int sharesToSell = 100;
+        final int expectedShares = stockOwnership.getShares();
+
+        assertThrows(IllegalArgumentException.class, () -> stockOwnership.sellShares(sharesToSell));
+
+        assertEquals(expectedShares, stockOwnership.getShares());
+    }
+
+    @Test
+    void itShouldBeAbleToGetTotalValue() {
+        final double expectedTotalValue = stockOwnership.getShares() * validStock.getPrice();
+        assertEquals(expectedTotalValue, stockOwnership.getTotalValue());
+    }
+}

--- a/src/test/java/com/mandacarubroker/domain/stock/UserTest.java
+++ b/src/test/java/com/mandacarubroker/domain/stock/UserTest.java
@@ -4,6 +4,7 @@ import com.mandacarubroker.domain.user.RequestUserDTO;
 import com.mandacarubroker.domain.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import com.mandacarubroker.exceptions.IllegalArgumentException;
 
 import java.time.LocalDate;
 

--- a/src/test/java/com/mandacarubroker/domain/user/UserTest.java
+++ b/src/test/java/com/mandacarubroker/domain/user/UserTest.java
@@ -1,4 +1,4 @@
-package com.mandacarubroker.domain.stock;
+package com.mandacarubroker.domain.user;
 
 import com.mandacarubroker.domain.user.RequestUserDTO;
 import com.mandacarubroker.domain.user.User;

--- a/src/test/java/com/mandacarubroker/domain/user/UserTest.java
+++ b/src/test/java/com/mandacarubroker/domain/user/UserTest.java
@@ -1,7 +1,5 @@
 package com.mandacarubroker.domain.user;
 
-import com.mandacarubroker.domain.user.RequestUserDTO;
-import com.mandacarubroker.domain.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import com.mandacarubroker.exceptions.IllegalArgumentException;
@@ -11,7 +9,7 @@ import java.time.LocalDate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class UserTest {
+class UserTest {
     private User user;
     private final RequestUserDTO requestUserDTO = new RequestUserDTO(
             "marcosloiola@yahoo.com",

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.mockStatic;
 public class PortfolioServiceTest {
         @MockBean
         private StockOwnershipRepository stockPositionRepository;
-        private StockService stockService;
         private UserRepository userRepository;
 
         @MockBean
@@ -74,12 +73,10 @@ public class PortfolioServiceTest {
                 stockRepository = Mockito.mock(StockRepository.class);
                 Mockito.when(stockPositionRepository.findByUserId(validUser.getId())).thenReturn(givenStockOwnerships);
 
-                stockService = Mockito.mock(StockService.class);
                 userRepository = Mockito.mock(UserRepository.class);
 
                 portfolioService = new PortfolioService(
                                 stockPositionRepository,
-                                stockService,
                                 stockRepository,
                                 userRepository);
         }

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -136,8 +136,8 @@ public class PortfolioServiceTest {
                 ResponseStockOwnershipDTO stockOwnership = portfolioService.getStockOwnershipByStockId(validUser, googleStock.getId());
 
                 assertResponseStockDTOEqualsStock(stockOwnership.stock(), responseGoogleStockDTO);
-                assertEquals(stockOwnership.totalShares(), 0);
-                assertEquals(stockOwnership.positionValue(), 0.00);
+                assertEquals(0, stockOwnership.totalShares());
+                assertEquals(0.00, stockOwnership.positionValue());
         }
 
         @Test

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -122,25 +122,22 @@ public class PortfolioServiceTest {
                 Mockito.when(stockOwnershipRepository.findByUserIdAndStockId(validUser.getId(), appleStock.getId()))
                         .thenReturn(appleStockOwnership);
 
-                Optional<ResponseStockOwnershipDTO> stockOwnership = portfolioService
-                        .getStockOwnershipByStockId(validUser, appleStock.getId());
+                ResponseStockOwnershipDTO stockOwnership = portfolioService.getStockOwnershipByStockId(validUser, appleStock.getId());
 
-                assertTrue(stockOwnership.isPresent());
-                assertResponseStockDTOEqualsStock(stockOwnership.get().stock(), responseAppleStockDTO);
-                assertEquals(stockOwnership.get().totalShares(), appleStockOwnership.getShares());
-                assertEquals(stockOwnership.get().positionValue(), appleStockOwnership.getTotalValue());
+                assertResponseStockDTOEqualsStock(stockOwnership.stock(), responseAppleStockDTO);
+                assertEquals(stockOwnership.totalShares(), appleStockOwnership.getShares());
+                assertEquals(stockOwnership.positionValue(), appleStockOwnership.getTotalValue());
         }
 
         @Test
         void itShouldReturnUserStockOwnershipWithZeroShares() {
                 Mockito.when(stockRepository.findById(googleStock.getId())).thenReturn(Optional.of(googleStock));
 
-                Optional<ResponseStockOwnershipDTO> stockOwnership = portfolioService.getStockOwnershipByStockId(validUser, googleStock.getId());
+                ResponseStockOwnershipDTO stockOwnership = portfolioService.getStockOwnershipByStockId(validUser, googleStock.getId());
 
-                assertTrue(stockOwnership.isPresent());
-                assertResponseStockDTOEqualsStock(stockOwnership.get().stock(), responseGoogleStockDTO);
-                assertEquals(stockOwnership.get().totalShares(), 0);
-                assertEquals(stockOwnership.get().positionValue(), 0.00);
+                assertResponseStockDTOEqualsStock(stockOwnership.stock(), responseGoogleStockDTO);
+                assertEquals(stockOwnership.totalShares(), 0);
+                assertEquals(stockOwnership.positionValue(), 0.00);
         }
 
         @Test

--- a/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/PortfolioServiceTest.java
@@ -11,6 +11,7 @@ import com.mandacarubroker.domain.stock.StockRepository;
 import com.mandacarubroker.domain.user.RequestUserDTO;
 import com.mandacarubroker.domain.user.User;
 import com.mandacarubroker.domain.user.UserRepository;
+import com.mandacarubroker.exceptions.NotFoundException;
 import com.mandacarubroker.security.SecuritySecretsMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,8 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.mandacarubroker.domain.stock.StockUtils.assertResponseStockDTOEqualsStock;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mockStatic;
 
 public class PortfolioServiceTest {
@@ -147,8 +147,8 @@ public class PortfolioServiceTest {
         void itShouldReturnEmptyWhenStockIsNotFound() {
                 Mockito.when(stockRepository.findById("invalid-stock-id")).thenReturn(Optional.empty());
 
-                Optional<ResponseStockOwnershipDTO> stockOwnership = portfolioService.getStockOwnershipByStockId(validUser, "invalid-stock-id");
-
-                assertTrue(stockOwnership.isEmpty());
+                assertThrows(NotFoundException.class, () -> {
+                        portfolioService.getStockOwnershipByStockId(validUser, "invalid-stock-id");
+                });
         }
 }


### PR DESCRIPTION
## Proposta deste PR

- Refatorar os métodos do portfólio de ativos para tornar-los mais coerentes e reutilizáveis
- Trocar as exceções HTTP por exceções comuns do java e adicionar um middleware para converter essas exceções em responses HTTP

## Impactos deste PR

- Remover exceções HTTP do Spring no Portfólio
- Criado método `getStockOwnership` para retornar o `StockOwnership` existente ou criar um novo
- Criado método `updateStockOwnership` para encapsular atualização da `StockOwnership` e possível deleção
- Criado os métodos `buyStock` e `sellStock` na classe `StockOwnership`

## Evidências de teste


![Screenshot 2024-03-19 at 08 56 26](https://github.com/izaiasmachado/mandacarubroker/assets/47287096/d96b2f3c-a356-413a-bfda-a0c057c7669f)

![Screenshot 2024-03-19 at 08 56 44](https://github.com/izaiasmachado/mandacarubroker/assets/47287096/7e858fa4-7760-4293-9877-c004550a6dbb)
